### PR TITLE
feat: Add dark mode toggle and theme support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from "@vercel/analytics/react"
+import { ThemeProvider } from "@/components/theme-provider";
 
 import "./globals.css";
 
@@ -26,13 +27,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
-        <SpeedInsights />
-        <Analytics />
+        <ThemeProvider
+          defaultTheme="system"
+          storageKey="vite-ui-theme"
+        >
+          {children}
+          <SpeedInsights />
+          <Analytics />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,12 @@
 
 import { useState, useRef } from 'react';
 import Image from 'next/image';
-import { Card, CardContent } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Download } from 'lucide-react';
+import { ThemeToggleButton } from '@/components/theme-toggle-button';
 
 const timeRanges = {
   '7day': "Last Week",
@@ -160,11 +161,11 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 py-12 px-4">
+    <div className="min-h-screen bg-background py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <Card className="mb-8">
           <CardContent className="pt-6">
-            <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex flex-col md:flex-row gap-4 items-center">
               <Input
                 type="text"
                 placeholder="LastFM Username"
@@ -173,7 +174,7 @@ export default function Home() {
                 className="flex-1"
               />
               <Select value={timeRange} onValueChange={setTimeRange}>
-                <SelectTrigger className="w-[180px]">
+                <SelectTrigger className="w-full md:w-[180px]">
                   <SelectValue placeholder="Select time range" />
                 </SelectTrigger>
                 <SelectContent>
@@ -187,11 +188,13 @@ export default function Home() {
               <Button
                 onClick={fetchTopAlbums}
                 disabled={loading}
+                className="w-full md:w-auto"
               >
                 {loading ? 'Loading...' : 'Generate Grid'}
               </Button>
+              <ThemeToggleButton />
             </div>
-            {error && <p className="text-red-500 mt-2">{error}</p>}
+            {error && <p className="text-red-500 dark:text-red-400 mt-2">{error}</p>}
           </CardContent>
         </Card>
 
@@ -220,7 +223,7 @@ export default function Home() {
                       <p className="font-semibold truncate">
                           <a href={`https://musicbrainz.org/release/${album.mbid}`}>{album.name}</a>
                       </p>
-                      <p className="text-sm text-gray-600 truncate">
+                      <p className="text-sm text-muted-foreground truncate">
                           <a href={`https://musicbrainz.org/artist/${album.artist.mbid}`}>{album.artist.name}</a>
                       </p>
                     </div>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeProviderState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState | undefined>(
+  undefined
+);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'system',
+  storageKey = 'vite-ui-theme',
+}: {
+  children: React.ReactNode;
+  defaultTheme?: Theme | 'system';
+  storageKey?: string;
+}) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const storedTheme = localStorage.getItem(storageKey) as Theme | null;
+      if (storedTheme) {
+        return storedTheme;
+      }
+    }
+    if (defaultTheme === 'system') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return defaultTheme as Theme;
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+        .matches
+        ? 'dark'
+        : 'light';
+      root.classList.add(systemTheme);
+      return;
+    }
+    root.classList.add(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(storageKey, theme);
+    }
+  }, [theme, storageKey]);
+
+  const value = {
+    theme,
+    setTheme: (newTheme: Theme) => {
+      setTheme(newTheme);
+    },
+  };
+
+  return (
+    <ThemeProviderContext.Provider value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/components/theme-toggle-button.tsx
+++ b/components/theme-toggle-button.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import * as React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/components/theme-provider'; // Corrected import path
+import { Button } from '@/components/ui/button'; // Assuming a Button component exists
+
+export function ThemeToggleButton() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
I implemented a dark mode feature for the application.

Key changes include:
- Added a `ThemeProvider` to manage theme state (light/dark/system) and persist your preference in local storage.
- Integrated the `ThemeProvider` into the root layout.
- Created a `ThemeToggleButton` component allowing you to switch between light and dark themes. This button uses Sun/Moon icons to indicate the current mode.
- Added the `ThemeToggleButton` to the main page controls.
- Updated `app/page.tsx` to use theme-aware styles (e.g., `bg-background`, `text-muted-foreground`) instead of hardcoded colors.
- Leveraged existing dark mode CSS variables defined in `app/globals.css`.

The application now respects your system preference by default and allows manual override via the toggle button. Theme settings are saved across sessions.