### PR TITLE
feat: Add fade-in animation to album cover images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -70,3 +70,11 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+.image-fade-enter {
+  opacity: 0;
+}
+.image-fade-enter-active {
+  opacity: 1;
+  transition: opacity 500ms ease-in-out;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 // app/page.tsx
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -45,6 +45,7 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [imageLoadingStates, setImageLoadingStates] = useState<{ [key: number]: boolean }>({});
 
   const fetchTopAlbums = async () => {
     if (!username) {
@@ -160,6 +161,14 @@ export default function Home() {
     }
   };
 
+  const handleImageLoad = (index: number) => {
+    setImageLoadingStates(prev => ({ ...prev, [index]: true }));
+  };
+
+  useEffect(() => {
+    setImageLoadingStates({});
+  }, [albums]);
+
   return (
     <div className="min-h-screen bg-background py-12 px-4">
       <div className="max-w-4xl mx-auto">
@@ -211,12 +220,13 @@ export default function Home() {
                 <Card key={index}>
                   <CardContent className="p-4">
                     <div className="aspect-square relative">
-                      <Image 
-                        src={album.image[3]?.['#text'] || '/api/placeholder/300/300' }
+                      <Image
+                        src={album.image[3]?.['#text'] || '/api/placeholder/300/300'}
                         alt={`${album.name} by ${album.artist.name}`}
                         fill
-                        className="object-cover"
+                        className={`object-cover ${!imageLoadingStates[index] ? 'image-fade-enter' : 'image-fade-enter-active'}`}
                         sizes="(max-width: 768px) 100vw, 300px"
+                        onLoad={() => handleImageLoad(index)}
                       />
                     </div>
                     <div className="mt-2">


### PR DESCRIPTION
This commit introduces a fade-in animation for album cover images when they are loaded on the page.

The animation is achieved using CSS transitions for opacity.
- A new CSS class `image-fade-enter` sets the initial opacity to 0.
- Another class `image-fade-enter-active` transitions the opacity to 1.

In `app/page.tsx`:
- A state variable `imageLoadingStates` has been added to track the loading status of each album image individually.
- The `next/image` component now uses the `onLoad` event to update this state when an image is loaded.
- The CSS classes are conditionally applied to the `Image` component based on its loading state, triggering the fade-in effect.
- A `useEffect` hook has been added to reset the `imageLoadingStates` when the `albums` array changes, ensuring animations trigger correctly for new sets of albums.