### PR TITLE
Style album and artist names in result tiles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -229,12 +229,12 @@ export default function Home() {
                         onLoad={() => handleImageLoad(index)}
                       />
                     </div>
-                    <div className="mt-2">
+                    <div className="mt-2 border rounded-md p-2">
                       <p className="font-semibold truncate">
-                          <a href={`https://musicbrainz.org/release/${album.mbid}`}>{album.name}</a>
+                          <a href={`https://musicbrainz.org/release/${album.mbid}`} className="text-blue-600 dark:text-blue-400 hover:underline">{album.name}</a>
                       </p>
                       <p className="text-sm text-muted-foreground truncate">
-                          <a href={`https://musicbrainz.org/artist/${album.artist.mbid}`}>{album.artist.name}</a>
+                          <a href={`https://musicbrainz.org/artist/${album.artist.mbid}`} className="text-sky-600 dark:text-sky-400 hover:underline">{album.artist.name}</a>
                       </p>
                     </div>
                   </CardContent>


### PR DESCRIPTION
This commit enhances the visual presentation of album and artist names within the result tiles.

Changes include:
- Added a border around the container of the album and artist names to visually group them.
- Styled the album name link with a distinct blue color and an underline on hover to clearly indicate it's clickable and leads to Musicbrainz.
- Styled the artist name link similarly with a sky blue color for consistency and clickability indication.

These changes improve the user interface by making the clickable elements more apparent and enhancing the overall aesthetic of the result tiles.