### PR TITLE
feat: Store and prefill username from localStorage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,6 +47,14 @@ export default function Home() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [imageLoadingStates, setImageLoadingStates] = useState<{ [key: number]: boolean }>({});
 
+  // Load username from localStorage on component mount
+  useEffect(() => {
+    const storedUsername = localStorage.getItem('username');
+    if (storedUsername) {
+      setUsername(storedUsername);
+    }
+  }, []); // Empty dependency array ensures this runs only once on mount
+
   const fetchTopAlbums = async () => {
     if (!username) {
       setError('Please enter a username');
@@ -75,6 +83,8 @@ export default function Home() {
       }));
 
       setAlbums(albumData);
+      // Save username to localStorage after successful fetch
+      localStorage.setItem('username', username);
     } catch (err) {
       console.error('An error occurred: ', err);
       setError('Error fetching albums. Please check the username and try again.');

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -49,6 +49,14 @@
         <h2>Information We Collect</h2>
         <p>We do not collect or store any personal data from our users. Our application does not use cookies or any other tracking technologies to gather information about you.</p>
 
+        <h2>Client-Side Storage</h2>
+        <p>For your convenience, our application utilizes the browser's <code>localStorage</code> to enhance your experience. Specifically, we store the last successfully used username directly in your browser.</p>
+        <ul>
+            <li><strong>Purpose:</strong> This is solely to prefill the username input field when you revisit the application, saving you from having to re-enter it each time.</li>
+            <li><strong>Locally Stored:</strong> This information is stored only on your computer within your web browser's local storage.</li>
+            <li><strong>No Transmission:</strong> The username stored in <code>localStorage</code> is not transmitted to our servers or any third-party services. It remains local to your browser session.</li>
+        </ul>
+
         <h2>Interaction with Third-Party Services</h2>
         <p>Our application interacts with Last.fm. When you use our application to access Last.fm services, any username or other information you provide for this purpose is sent directly to Last.fm's servers. We do not store this information on our servers. We encourage you to review Last.fm's privacy policy to understand how they handle your data.</p>
 


### PR DESCRIPTION
This commit introduces client-side storage for the last used username to enhance your experience by prefilling the username input field.

Changes include:
- Modified `app/page.tsx` to save the username to `localStorage` upon successful API calls and to load it when the page initializes.
- Updated `public/privacy.html` to inform you about the storage of your username in the browser's `localStorage` for convenience, clarifying that this data is stored locally and not sent to servers.