### PR TITLE
feat: Cache Spotify links in Redis

### DIFF
--- a/app/api/spotify-link/route.ts
+++ b/app/api/spotify-link/route.ts
@@ -77,11 +77,11 @@ export async function GET(req: NextRequest) {
     if (searchResponse.body.albums && searchResponse.body.albums.items.length > 0) {
       const spotifyUrl = searchResponse.body.albums.items[0].external_urls.spotify;
       // Cache the found link in Redis for 24 hours
-      await redis.set(cacheKey, spotifyUrl, { ex: 86400 });
+      await redis.set(cacheKey, spotifyUrl, 'EX', 86400);
       return NextResponse.json({ spotifyUrl }, { status: 200 });
     } else {
       // Cache "SPOTIFY_NOT_FOUND" for 1 hour
-      await redis.set(cacheKey, "SPOTIFY_NOT_FOUND", { ex: 3600 });
+      await redis.set(cacheKey, "SPOTIFY_NOT_FOUND", 'EX', 3600);
       return NextResponse.json(
         { spotifyUrl: null, message: 'Album not found on Spotify' },
         { status: 200 } // Changed to 200 as per instruction for client simplicity


### PR DESCRIPTION
Implement Redis caching for Spotify album links to reduce API calls and improve response times.

- Before fetching from the Spotify API, I now check Redis for a cached link using a key derived from the album and artist name.
- If a link is found in Redis, it's returned directly.
- If an album was previously determined not to be on Spotify, this "not found" status is also cached (with a shorter TTL) and returned without an API call.
- If no cache entry exists, the Spotify API is queried. The resulting link (or "not found" status) is then cached in Redis for future requests.
- Spotify links are cached for 24 hours.
- "Not found" statuses are cached for 1 hour.
- Unit tests have been updated to mock the Redis client and verify the caching logic, including cache hits, misses, and the caching of "not found" states.