### PR TITLE
feat: Add subtle visual cue for albums with Spotify links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -420,13 +420,15 @@ export default function Home() {
                           onLoad={() => handleImageLoad(index)}
                         />
                         {showCue && (
-                          <Image
-                            src="/spotify_icon.svg"
-                            alt="Spotify Playable Cue"
-                            width={24}
-                            height={24}
-                            className="absolute top-2 right-2 w-6 h-6 opacity-75 z-10"
-                          />
+                          <div className="absolute top-2 right-2 z-10 p-0.5 bg-black/20 rounded-sm flex items-center justify-center">
+                            <Image
+                              src="/spotify_icon.svg"
+                              alt="Spotify Playable Cue"
+                              width={24}
+                              height={24}
+                              className="w-6 h-6 opacity-75"
+                            />
+                          </div>
                         )}
                         {currentSpotifyUrl && (
                           <a


### PR DESCRIPTION
This commit introduces a visual indicator on album art for albums that have an associated Spotify link.

Key changes:
- A small, semi-transparent Spotify icon is now displayed in the top-right corner of the album art if a Spotify link is available. This cue is visible before any hover interaction.
- The existing hover effect (album art dimming, larger Spotify logo fading in) remains fully functional.
- The new visual cue is hidden when the main hover-activated Spotify logo appears, providing a clean user experience.
- State management was updated in `app/page.tsx` to track and render this cue conditionally.