### PR TITLE
feat: Open grid image in new tab instead of downloading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,9 +169,21 @@ export default function Home() {
       ctx.textAlign = 'center';
       ctx.fillText(`${username}'s Top Albums - ${timeRanges[timeRange as keyof typeof timeRanges]}`, canvas.width / 2, canvas.height - 10);
 
-      // Open image in a new tab
+      // Open image in a new tab (revised approach)
       const imageURL = canvas.toDataURL('image/jpeg', 0.8);
-      window.open(imageURL, '_blank');
+      const newWindow = window.open('', '_blank');
+      if (newWindow) {
+        newWindow.document.write('<html><head><title>Album Grid</title></head><body><img src="' + imageURL + '" style="display: block; margin: auto; max-width: 100%; max-height: 100vh;"></body></html>');
+        newWindow.document.close(); // Important for some browsers
+      } else {
+        // Fallback or error message if popup was blocked
+        alert('Failed to open new tab. Please disable your popup blocker and try again.');
+        // Optionally, revert to direct download as a fallback:
+        // const link = document.createElement('a');
+        // link.download = `${username}-${timeRange}-albums.jpg`;
+        // link.href = imageURL;
+        // link.click();
+      }
     } catch (error) {
       console.error('Error generating image:', error);
       setError('Error generating image. Please try again.');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,11 +169,9 @@ export default function Home() {
       ctx.textAlign = 'center';
       ctx.fillText(`${username}'s Top Albums - ${timeRanges[timeRange as keyof typeof timeRanges]}`, canvas.width / 2, canvas.height - 10);
 
-      // Trigger download
-      const link = document.createElement('a');
-      link.download = `${username}-${timeRange}-albums.jpg`;
-      link.href = canvas.toDataURL('image/jpeg', 0.8);
-      link.click();
+      // Open image in a new tab
+      const imageURL = canvas.toDataURL('image/jpeg', 0.8);
+      window.open(imageURL, '_blank');
     } catch (error) {
       console.error('Error generating image:', error);
       setError('Error generating image. Please try again.');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,12 +177,12 @@ export default function Home() {
         newWindow.document.close(); // Important for some browsers
       } else {
         // Fallback or error message if popup was blocked
-        alert('Failed to open new tab. Please disable your popup blocker and try again.');
+        //alert('Failed to open new tab. Please disable your popup blocker and try again.');
         // Optionally, revert to direct download as a fallback:
-        // const link = document.createElement('a');
-        // link.download = `${username}-${timeRange}-albums.jpg`;
-        // link.href = imageURL;
-        // link.click();
+        const link = document.createElement('a');
+        link.download = `${username}-${timeRange}-albums.jpg`;
+        link.href = imageURL;
+        link.click();
       }
     } catch (error) {
       console.error('Error generating image:', error);


### PR DESCRIPTION
I modified the 'Download Grid' button functionality for you.

Previously, clicking the button initiated a direct download of the generated grid image.

This change updates the behavior to open the grid image (JPEG format) in a new browser tab. This allows you to view and interact with the image within the browser before deciding to save it.

The `generateImage` function in `app/page.tsx` was updated to use `window.open()` with the canvas data URL, replacing the previous download-triggering mechanism.