### PR TITLE
Feat: Implement JPG grid conversion and revert functionality

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Download } from 'lucide-react';
+import { Download, FileImage } from 'lucide-react';
 import { ThemeToggleButton } from '@/components/theme-toggle-button';
 
 const timeRanges = {
@@ -338,6 +338,15 @@ export default function Home() {
     return () => clearTimeout(timer); // Cleanup timer
   }, [isGridUpdating]);
 
+  const handleToggleView = () => {
+    if (isJpgView) {
+      setIsJpgView(false);
+      setJpgImageData(''); // Ensure this line is present
+    } else {
+      generateImage();
+    }
+  };
+
   return (
     <div className="min-h-screen bg-background py-12 px-4">
       <div className="max-w-4xl mx-auto">
@@ -399,21 +408,14 @@ export default function Home() {
           <>
             <div className="flex justify-end mb-4">
               <Button
-                onClick={() => {
-                  if (isJpgView) {
-                    setIsJpgView(false);
-                    setJpgImageData(''); // Add this line
-                  } else {
-                    generateImage();
-                  }
-                }}
+                onClick={handleToggleView} // Update this line
                 className="gap-2"
               >
                 {isJpgView ? (
                   'Revert to Grid'
                 ) : (
                   <>
-                    <Download size={16} />
+                    <FileImage size={16} />
                     Convert to JPG
                   </>
                 )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,6 +65,7 @@ export default function Home() {
   }, []); // Empty dependency array ensures this runs only once on mount
 
   const fetchTopAlbums = async () => {
+    setIsJpgView(false); // Add this line
     if (!username) {
       setError('Please enter a username');
       return;
@@ -401,6 +402,7 @@ export default function Home() {
                 onClick={() => {
                   if (isJpgView) {
                     setIsJpgView(false);
+                    setJpgImageData(''); // Add this line
                   } else {
                     generateImage();
                   }


### PR DESCRIPTION
Replaces the "Download Grid" button with "Convert to JPG". When "Convert to JPG" is clicked:
- The HTML grid is replaced by a JPG image rendition of the grid.
- The button text changes to "Revert to Grid".

When "Revert to Grid" is clicked:
- The JPG image is replaced by the original HTML grid.
- The button text changes back to "Convert to JPG".

This change modifies `app/page.tsx` to include:
- New state variables `jpgImageData` and `isJpgView` to manage the display mode and JPG data.
- Updated `generateImage` function to store the JPG data in state instead of opening a new tab.
- Modified action button logic to handle the two states (convert/revert).
- Conditional rendering to display either the HTML grid or the JPG image.