### PR TITLE
Fix: Display full album/artist name on hover

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -478,10 +478,10 @@ export default function Home() {
                           )}
                         </div>
                         <div className="mt-2">
-                        <p className="font-semibold truncate">
+<p className="font-semibold truncate" title={album.name}>
                             <a href={`https://musicbrainz.org/release/${album.mbid}`} target="_blank" rel="noopener noreferrer">{album.name}</a>
                         </p>
-                        <p className="text-sm text-muted-foreground truncate">
+<p className="text-sm text-muted-foreground truncate" title={album.artist.name}>
                             <a href={`https://musicbrainz.org/artist/${album.artist.mbid}`} target="_blank" rel="noopener noreferrer">{album.artist.name}</a>
                         </p>
                       </div>


### PR DESCRIPTION
Previously, long album and artist names were truncated with an ellipsis.

This change adds a 'title' attribute to the album and artist name elements. This allows the full name to be displayed in a tooltip when you hover over a truncated name, improving usability for entries with long text.