### PR TITLE
feat: Add Ko-fi donation link to footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,6 +56,7 @@ export default function RootLayout({
           <Analytics />
           <footer>
             <a href="/privacy.html">Privacy Policy</a>
+            <a href="https://ko-fi.com/YOUR_KOFI_USERNAME" target="_blank" rel="noopener noreferrer" style={{ marginRight: '10px' }}>Support me on Ko-fi</a>
             <div className="copyright">
               © {new Date().getFullYear()} LastFM Album Collage Generator. All Rights Reserved.
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
           <Analytics />
           <footer>
             <a href="/privacy.html">Privacy Policy</a>
-            <a href="https://ko-fi.com/YOUR_KOFI_USERNAME" target="_blank" rel="noopener noreferrer" style={{ marginRight: '10px' }}>Support me on Ko-fi</a>
+            <a href="https://ko-fi.com/paddez" target="_blank" rel="noopener noreferrer" style={{ marginRight: '10px' }}>Support me on Ko-fi</a>
             <div className="copyright">
               © {new Date().getFullYear()} LastFM Album Collage Generator. All Rights Reserved.
             </div>


### PR DESCRIPTION
Adds a "Support me on Ko-fi" link to the website footer. The link opens in a new tab and includes a placeholder for your Ko-fi username.

The link inherits existing footer link styles for visual consistency. This provides users with an option to support the project financially via Ko-fi.