### PR TITLE
feat: Add sitemap.xml for SEO

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'; // Fallback for local dev
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/privacy.html`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
This commit introduces a sitemap for the website, generated dynamically.

The sitemap includes:
- The home page (/)
- The privacy page (/privacy.html)

It uses the `NEXT_PUBLIC_BASE_URL` environment variable to construct absolute URLs, defaulting to `http://localhost:3000` if the variable is not set.

This will help search engines better crawl and index the website.