### PR TITLE
feat: Improve CLS on Share/[id] page by adding skeleton loader

### DIFF
--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
 import type { SharedGridData, MinimizedAlbum } from '@/lib/types';
 import { logger } from '@/utils/logger';
+import SharePageSkeleton from '@/components/share-page-skeleton';
 
 const CTX = 'SharePage';
 
@@ -217,11 +218,7 @@ export default function SharedGridPage() {
   }, [sharedData, id]);
 
   if (loading) {
-    return (
-      <div className="container mx-auto p-4 text-center">
-        <p className="text-lg">Loading shared grid...</p>
-      </div>
-    );
+    return <SharePageSkeleton />;
   }
 
   if (error) {

--- a/components/share-page-skeleton.tsx
+++ b/components/share-page-skeleton.tsx
@@ -1,0 +1,33 @@
+// components/share-page-skeleton.tsx
+import { Card, CardContent } from '@/components/ui/card';
+
+const SharePageSkeleton = () => {
+  return (
+    <div className="min-h-screen bg-background py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        {/* Header Placeholder */}
+        <header className="text-center mb-8 space-y-2">
+          <div className="h-4 bg-muted animate-pulse rounded w-3/4 mx-auto"></div>
+          <div className="h-4 bg-muted animate-pulse rounded w-1/2 mx-auto"></div>
+        </header>
+
+        {/* Grid Placeholder */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Card key={index} className="flex flex-col">
+              <CardContent className="p-4">
+                <div className="aspect-square bg-muted animate-pulse"></div>
+                <div className="mt-2 space-y-2">
+                  <div className="h-4 bg-muted animate-pulse rounded w-5/6"></div>
+                  <div className="h-4 bg-muted animate-pulse rounded w-3/4"></div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SharePageSkeleton;


### PR DESCRIPTION
I've introduced a skeleton loading component (`SharePageSkeleton`) for the `Share/[id]` page. This component mimics the page's structure (header and album grid) while data is being fetched, significantly reducing Cumulative Layout Shift (CLS).

Previously, a simple "Loading..." message was shown, causing a large layout shift when the actual content loaded. The new skeleton loader reserves space for the main elements, providing a much smoother and more visually stable loading experience.

I've also verified that existing image loading practices (using `next/image` with `fill`, `sizes`, and `aspect-square` containers) and the conditionally rendered Spotify cue icon (absolutely positioned and explicitly sized) are robust and not contributing to CLS.