### PR TITLE
⚡ Optimize Spotify link fetching with bulk API and decoupled UI logic

### DIFF
--- a/app/api/spotify-links/route.ts
+++ b/app/api/spotify-links/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { searchAlbumsBulk } from '@/lib/spotifyService';
+import { logger } from '@/utils/logger';
+
+const CTX = 'SpotifyLinksBulkAPI';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { albums } = body;
+
+    if (!albums || !Array.isArray(albums)) {
+      return NextResponse.json(
+        { message: 'Missing or invalid required parameter: albums' },
+        { status: 400 }
+      );
+    }
+
+    if (albums.length === 0) {
+      return NextResponse.json({}, { status: 200 });
+    }
+
+    logger.info(CTX, `Received bulk request for ${albums.length} albums`);
+
+    const results = await searchAlbumsBulk(albums);
+
+    return NextResponse.json(results, { status: 200 });
+  } catch (error) {
+    logger.error(
+      CTX,
+      `Error in bulk Spotify links API: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return NextResponse.json(
+      { message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/share/[id]/SharePageClient.tsx
+++ b/app/share/[id]/SharePageClient.tsx
@@ -141,38 +141,15 @@ export default function SharePageClient() {
       });
       setLogoColorStates(initialLogoColorStates);
 
-      const fetchPromises = sharedData.albums.map(async (album) => {
+      const albumsToFetch = sharedData.albums.map((album) => ({
+        name: album.name,
+        artistName: album.artist.name,
+        mbid: album.mbid,
+      }));
+
+      // 1. Decouple image analysis: Start it immediately for all albums
+      sharedData.albums.forEach((album) => {
         const albumKey = album.mbid;
-        try {
-          const response = await fetch(
-            `/api/spotify-link?artistName=${encodeURIComponent(
-              album.artist.name
-            )}&albumName=${encodeURIComponent(album.name)}`
-          );
-          if (!response.ok) {
-            logger.warn(
-              CTX,
-              `Spotify link API error for ${albumKey}, status: ${response.status}`
-            );
-            newSpotifyLinks[albumKey] = null;
-          } else {
-            const data = await response.json();
-            newSpotifyLinks[albumKey] = data.spotifyUrl || null;
-            logger.info(
-              CTX,
-              `Spotify link for ${albumKey}: ${data.spotifyUrl}`
-            );
-          }
-        } catch (e) {
-          logger.error(
-            CTX,
-            `Error fetching Spotify link for ${albumKey}: ${e instanceof Error ? e.message : String(e)}`
-          );
-          newSpotifyLinks[albumKey] = null;
-        }
-
-        newSpotifyCueVisible[albumKey] = !!newSpotifyLinks[albumKey];
-
         if (album.imageUrl) {
           getLogoBackgroundColorType(album.imageUrl, albumKey);
         } else {
@@ -180,14 +157,30 @@ export default function SharePageClient() {
         }
       });
 
-      Promise.all(fetchPromises)
-        .then(() => {
+      // 2. Fetch Spotify links in bulk
+      fetch('/api/spotify-links', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ albums: albumsToFetch }),
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`Bulk Spotify links API error: ${response.status}`);
+          }
+          const results: Record<string, string | null> = await response.json();
+
+          sharedData.albums.forEach((album) => {
+            const albumKey = album.mbid;
+            const spotifyUrl = results[albumKey] || null;
+            newSpotifyLinks[albumKey] = spotifyUrl;
+            newSpotifyCueVisible[albumKey] = !!spotifyUrl;
+          });
+
           setSpotifyLinks(newSpotifyLinks);
           setSpotifyCueVisible(newSpotifyCueVisible);
-          logger.info(
-            CTX,
-            'Finished fetching all Spotify links and analyzing images.'
-          );
+          logger.info(CTX, 'Finished fetching bulk Spotify links.');
         })
         .catch((e) => {
           logger.error(

--- a/lib/spotifyService.ts
+++ b/lib/spotifyService.ts
@@ -115,3 +115,127 @@ export async function searchAlbum(
     return { spotifyUrl: null };
   }
 }
+
+/**
+ * Bulk searches for albums on Spotify.
+ * Utilizes Redis MGET for efficient cache retrieval.
+ *
+ * @param {Array<{name: string, artistName: string, mbid: string}>} albums Array of albums to search.
+ * @returns {Promise<Record<string, string | null>>} A map of mbid to Spotify URL.
+ */
+export async function searchAlbumsBulk(
+  albums: { name: string; artistName: string; mbid: string }[]
+): Promise<Record<string, string | null>> {
+  const results: Record<string, string | null> = {};
+  if (albums.length === 0) return results;
+
+  const notFoundRedisPlaceholder = 'SPOTIFY_NOT_FOUND';
+  const defaultCacheExpiry = 86400; // 24 hours
+  const defaultNotFoundCacheExpiry = 3600; // 1 hour
+
+  // 1. Prepare cache keys
+  const cacheEntries = albums.map((album) => ({
+    mbid: album.mbid,
+    key: `spotify:link:${encodeURIComponent(album.artistName)}:${encodeURIComponent(album.name)}`,
+    album,
+  }));
+  const cacheKeys = cacheEntries.map((e) => e.key);
+
+  // 2. MGET from Redis
+  let cachedValues: (string | null)[] = [];
+  try {
+    cachedValues = await redis.mget(...cacheKeys);
+  } catch (error) {
+    logger.error(
+      CTX,
+      `Error during Redis MGET: ${error instanceof Error ? error.message : String(error)}`
+    );
+    cachedValues = new Array(cacheKeys.length).fill(null);
+  }
+
+  const missIndices: number[] = [];
+
+  cachedValues.forEach((val, index) => {
+    const { mbid } = cacheEntries[index];
+    if (val === null) {
+      missIndices.push(index);
+    } else if (val === notFoundRedisPlaceholder) {
+      results[mbid] = null;
+    } else {
+      try {
+        const parsed = JSON.parse(val);
+        results[mbid] = parsed.spotifyUrl || null;
+      } catch (e) {
+        // Fallback if not JSON or different structure
+        results[mbid] = val;
+      }
+    }
+  });
+
+  if (missIndices.length === 0) {
+    logger.info(CTX, `Bulk search: All ${albums.length} albums found in cache.`);
+    return results;
+  }
+
+  logger.info(
+    CTX,
+    `Bulk search: Cache miss for ${missIndices.length}/${albums.length} albums, fetching from Spotify...`
+  );
+
+  // 3. Fetch misses
+  try {
+    await getAccessToken();
+  } catch (e) {
+    logger.error(CTX, `Failed to get access token for bulk search: ${e}`);
+    missIndices.forEach((index) => {
+      results[cacheEntries[index].mbid] = null;
+    });
+    return results;
+  }
+
+  const spotifyApi = getSpotifyApiInstance();
+
+  const fetchPromises = missIndices.map(async (index) => {
+    const { album, key, mbid } = cacheEntries[index];
+    try {
+      logger.info(
+        CTX,
+        `Bulk Search: Fetching fresh for ${album.name} by ${album.artistName}`
+      );
+      const query = `album:${album.name} artist:${album.artistName}`;
+      const response = await spotifyApi.searchAlbums(query, { limit: 1 });
+
+      let spotifyUrl: string | null = null;
+      if (response.body.albums && response.body.albums.items.length > 0) {
+        spotifyUrl = response.body.albums.items[0].external_urls.spotify;
+      }
+
+      results[mbid] = spotifyUrl;
+
+      // Cache the result
+      if (spotifyUrl) {
+        await redis.setex(
+          key,
+          defaultCacheExpiry,
+          JSON.stringify({ spotifyUrl })
+        );
+      } else {
+        await redis.setex(
+          key,
+          defaultNotFoundCacheExpiry,
+          notFoundRedisPlaceholder
+        );
+      }
+    } catch (error) {
+      logger.error(
+        CTX,
+        `Error searching for album ${album.name} in bulk: ${error instanceof Error ? error.message : String(error)}`
+      );
+      results[mbid] = null;
+    }
+  });
+
+  await Promise.all(fetchPromises);
+
+  return results;
+}


### PR DESCRIPTION
This PR addresses an N+1 performance issue where the `SharePageClient` was making individual API calls for every album in a shared grid. 

**Changes:**
1. **Bulk Service Implementation:** Added `searchAlbumsBulk` to `lib/spotifyService.ts`. It uses Redis `mget` to check multiple cache keys at once, significantly reducing round-trips to the cache. For cache misses, it fetches from the Spotify API in parallel using `Promise.all`.
2. **New Bulk API Endpoint:** Created `/api/spotify-links` (POST) to handle batch requests from the frontend.
3. **Frontend Optimization:** Refactored `SharePageClient.tsx` to use the new bulk endpoint. 
4. **UX Improvement:** Decoupled image analysis (logo background color detection) from Spotify fetching. This allows the page to start processing visual themes immediately without waiting for the Spotify network request to complete or worrying about its failure.

**Performance Impact:**
- Reduced network requests from $N+1$ to 2 (one for shared data, one for all Spotify links).
- Improved perceived performance by parallelizing image analysis with network requests.
- Increased resilience by handling individual album fetch failures gracefully within the bulk operation.

---
*PR created automatically by Jules for task [17066473584145636238](https://jules.google.com/task/17066473584145636238) started by @Irishsmurf*