### PR TITLE
fix: stop metrics timer and increment counter on all early-return paths (#85)

### DIFF
--- a/app/api/albums/route.test.ts
+++ b/app/api/albums/route.test.ts
@@ -262,6 +262,70 @@ describe('GET /api/albums', () => {
     expect(responseBody.message).toBe('Error fetching albums');
   });
 
+  it('should call end() and increment counter on invalid limit', async () => {
+    const { apiRequestCounter, apiRequestDuration } = require('../../../lib/metrics');
+    const mockEnd = jest.fn();
+    (apiRequestDuration.startTimer as jest.Mock).mockReturnValue(mockEnd);
+
+    const url = 'http://localhost:3000/api/albums?username=testuser&period=7day&limit=999';
+    const req = new Request(url) as any;
+    const response = await GET(req);
+
+    expect(response.status).toBe(400);
+    expect(mockEnd).toHaveBeenCalled();
+    expect(apiRequestCounter.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ status_code: '400' })
+    );
+  });
+
+  it('should call end() and increment counter on invalid username', async () => {
+    const { apiRequestCounter, apiRequestDuration } = require('../../../lib/metrics');
+    const mockEnd = jest.fn();
+    (apiRequestDuration.startTimer as jest.Mock).mockReturnValue(mockEnd);
+
+    const url = 'http://localhost:3000/api/albums?username=x&period=7day';
+    const req = new Request(url) as any;
+    const response = await GET(req);
+
+    expect(response.status).toBe(400);
+    expect(mockEnd).toHaveBeenCalled();
+    expect(apiRequestCounter.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ status_code: '400' })
+    );
+  });
+
+  it('should call end() and increment counter on invalid period', async () => {
+    const { apiRequestCounter, apiRequestDuration } = require('../../../lib/metrics');
+    const mockEnd = jest.fn();
+    (apiRequestDuration.startTimer as jest.Mock).mockReturnValue(mockEnd);
+
+    const url = 'http://localhost:3000/api/albums?username=testuser&period=badperiod';
+    const req = new Request(url) as any;
+    const response = await GET(req);
+
+    expect(response.status).toBe(400);
+    expect(mockEnd).toHaveBeenCalled();
+    expect(apiRequestCounter.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ status_code: '400' })
+    );
+  });
+
+  it('should call end() and increment counter on missing username/period', async () => {
+    const { apiRequestCounter, apiRequestDuration } = require('../../../lib/metrics');
+    const mockEnd = jest.fn();
+    (apiRequestDuration.startTimer as jest.Mock).mockReturnValue(mockEnd);
+
+    const url = 'http://localhost:3000/api/albums';
+    const req = new Request(url) as any;
+    const response = await GET(req);
+
+    expect(response.status).toBe(400);
+    expect(mockEnd).toHaveBeenCalled();
+    expect(apiRequestCounter.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ status_code: '400' })
+    );
+  });
+
   it('should return 500 when a network error is thrown', async () => {
     const mockUsername = 'testuser';
     const mockPeriod = 'overall';

--- a/app/api/albums/route.ts
+++ b/app/api/albums/route.ts
@@ -34,6 +34,8 @@ export async function GET(req: NextRequest) {
 
   if (limitParam && !validLimits.includes(limit)) {
     logger.warn(CTX, `Invalid limit: ${limitParam}`);
+    apiRequestCounter.inc({ method: 'GET', route: '/api/albums', status_code: '400' });
+    end();
     return NextResponse.json(
       { message: 'Invalid limit. Must be 9, 16, or 25.' },
       { status: 400 }
@@ -48,6 +50,8 @@ export async function GET(req: NextRequest) {
   // Validate username
   if (username && (username.length < 2 || username.length > 50)) {
     logger.warn(CTX, `Invalid username: ${username}`);
+    apiRequestCounter.inc({ method: 'GET', route: '/api/albums', status_code: '400' });
+    end();
     return NextResponse.json(
       { message: 'Invalid username. Must be between 2 and 50 characters.' },
       { status: 400 }
@@ -65,6 +69,8 @@ export async function GET(req: NextRequest) {
   ];
   if (period && !validPeriods.includes(period)) {
     logger.warn(CTX, `Invalid period: ${period}`);
+    apiRequestCounter.inc({ method: 'GET', route: '/api/albums', status_code: '400' });
+    end();
     return NextResponse.json({ message: 'Invalid period.' }, { status: 400 });
   }
 
@@ -75,6 +81,8 @@ export async function GET(req: NextRequest) {
 
   if (!username || !period) {
     logger.warn(CTX, 'Missing username or period in request');
+    apiRequestCounter.inc({ method: 'GET', route: '/api/albums', status_code: '400' });
+    end();
     return NextResponse.json(
       { message: 'Username and period are required' },
       { status: 400 }


### PR DESCRIPTION
Closes #85

## Changes
- Added `end()` call before every early-return `NextResponse.json(...)` in the albums route handler
- Added `apiRequestCounter.inc()` with `status_code: '400'` on all validation failure paths
- Added 4 new tests confirming counter/timer behaviour on invalid limit, username, period, and missing params

## Testing
- All 10 tests pass in `app/api/albums/route.test.ts`
- No new Prometheus label cardinality introduced (histogram only has method/route labels)