### PR TITLE
Fix grid flash when toggling labels in JPG view

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -814,14 +814,18 @@ export default function Home() {
             </div>
 
             {isJpgView &&
+            // Prefer the JPG matching the current label state, but fall back to
+            // the other cached JPG while the requested one is still generating.
+            // This prevents a momentary flash of the underlying grid when
+            // toggling labels on/off in JPG view.
             (showAlbumLabels
-              ? jpgImageCache.withLabels
-              : jpgImageCache.withoutLabels) ? (
+              ? jpgImageCache.withLabels || jpgImageCache.withoutLabels
+              : jpgImageCache.withoutLabels || jpgImageCache.withLabels) ? (
               <Image
                 src={
                   showAlbumLabels
-                    ? jpgImageCache.withLabels
-                    : jpgImageCache.withoutLabels
+                    ? jpgImageCache.withLabels || jpgImageCache.withoutLabels
+                    : jpgImageCache.withoutLabels || jpgImageCache.withLabels
                 }
                 alt="Album Grid JPG"
                 width={1800}


### PR DESCRIPTION
## Problem

After converting the album grid to JPG, clicking **"Labels On"** (or "Labels Off") momentarily flashed the underlying album grid view before the labeled JPG appeared.

## Root cause

In `app/page.tsx`, the render branch chose the JPG only when the cache entry matching the current label state was present:

```jsx
{isJpgView &&
(showAlbumLabels ? jpgImageCache.withLabels : jpgImageCache.withoutLabels) ? (
  <Image ... />
) : (
  <div data-testid="album-grid-container" /> // the grid
)}
```

Toggling labels updates `showAlbumLabels` synchronously, but the matching JPG (`withLabels`) is generated asynchronously via `generateImage()`. During that gap the cache entry is still an empty string, so the condition fell through to the **grid** branch — the flash.

## Fix

While in JPG view, fall back to the other already-cached JPG until the requested one finishes generating, so the grid never re-appears mid-toggle. The image simply swaps from the stale JPG to the freshly-labeled one once ready.

## Testing

- `npm test -- --testPathPattern=page.test` → all passing
- `npx eslint app/page.tsx` → no new warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo2htPsoTznVRVFf2RULHy)_