### PR TITLE
Fix UI jank when toggling between JPG and Grid view

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { FileImage, Share2, Check, Loader2 } from 'lucide-react'; // Added Share2, Check, Loader2
+import { FileImage, LayoutGrid, Share2, Check, Loader2 } from 'lucide-react'; // Added Share2, Check, Loader2, LayoutGrid
 import { ThemeToggleButton } from '@/components/theme-toggle-button';
 import type { MinimizedAlbum } from '@/lib/minimizedLastfmService'; // Import MinimizedAlbum
 import {
@@ -769,52 +769,63 @@ export default function Home() {
                     {shareCopied ? 'Copied!' : 'Share Grid'}
                   </Button>
                 )}
-                {isJpgView && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={async () => {
-                      const next = !showAlbumLabels;
-                      setShowAlbumLabels(next);
-                      const cached = next
-                        ? jpgImageCache.withLabels
-                        : jpgImageCache.withoutLabels;
-                      // Only spin while a new image is being generated. When the
-                      // requested variant is already cached the swap is instant.
-                      if (!cached) {
-                        setIsGeneratingLabels(true);
-                        try {
-                          await generateImage(next);
-                        } finally {
-                          setIsGeneratingLabels(false);
-                        }
+                {/* Always mounted so it reserves its slot in the row. When not
+                    in JPG view it's hidden but keeps its footprint, so entering
+                    JPG view reveals it in place instead of pushing neighbors. */}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={async () => {
+                    const next = !showAlbumLabels;
+                    setShowAlbumLabels(next);
+                    const cached = next
+                      ? jpgImageCache.withLabels
+                      : jpgImageCache.withoutLabels;
+                    // Only spin while a new image is being generated. When the
+                    // requested variant is already cached the swap is instant.
+                    if (!cached) {
+                      setIsGeneratingLabels(true);
+                      try {
+                        await generateImage(next);
+                      } finally {
+                        setIsGeneratingLabels(false);
                       }
-                    }}
-                    disabled={isGeneratingLabels}
-                    className={cn(
-                      // min-width keeps the button from shrinking when its text
-                      // is swapped for the spinner, avoiding layout shift.
-                      'gap-1.5 h-8 text-xs min-w-[5.5rem]',
-                      showAlbumLabels &&
-                        'border-brand-red text-brand-red hover:text-brand-red-dark'
-                    )}
-                  >
-                    {isGeneratingLabels ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : showAlbumLabels ? (
-                      'Labels On'
-                    ) : (
-                      'Labels Off'
-                    )}
-                  </Button>
-                )}
+                    }
+                  }}
+                  disabled={isGeneratingLabels || !isJpgView}
+                  aria-hidden={!isJpgView}
+                  tabIndex={isJpgView ? undefined : -1}
+                  className={cn(
+                    // min-width keeps the button from shrinking when its text
+                    // is swapped for the spinner, avoiding layout shift.
+                    'gap-1.5 h-8 text-xs min-w-[5.5rem] transition-opacity duration-200',
+                    // Hidden but space-reserving outside JPG view to avoid the
+                    // row reflowing when the button appears.
+                    !isJpgView && 'invisible pointer-events-none',
+                    showAlbumLabels &&
+                      'border-brand-red text-brand-red hover:text-brand-red-dark'
+                  )}
+                >
+                  {isGeneratingLabels ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : showAlbumLabels ? (
+                    'Labels On'
+                  ) : (
+                    'Labels Off'
+                  )}
+                </Button>
                 <Button
                   size="sm"
                   onClick={handleToggleView}
-                  className="gap-1.5 h-8 text-xs bg-brand-red hover:bg-brand-red-dark text-white"
+                  // min-width + a consistent leading icon keep this button a
+                  // fixed size across both states, so toggling never resizes it.
+                  className="gap-1.5 h-8 text-xs min-w-[8.5rem] justify-center bg-brand-red hover:bg-brand-red-dark text-white"
                 >
                   {isJpgView ? (
-                    'Revert to Grid'
+                    <>
+                      <LayoutGrid size={13} />
+                      Revert to Grid
+                    </>
                   ) : (
                     <>
                       <FileImage size={13} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -800,8 +800,13 @@ export default function Home() {
                     // is swapped for the spinner, avoiding layout shift.
                     'gap-1.5 h-8 text-xs min-w-[5.5rem] transition-opacity duration-200',
                     // Hidden but space-reserving outside JPG view to avoid the
-                    // row reflowing when the button appears.
-                    !isJpgView && 'invisible pointer-events-none',
+                    // row reflowing when the button appears. opacity (not
+                    // visibility) keeps the footprint while letting the button
+                    // fade in; disabled:opacity-0 overrides the base Button's
+                    // disabled:opacity-50 so it goes fully transparent.
+                    !isJpgView
+                      ? 'opacity-0 disabled:opacity-0 pointer-events-none'
+                      : 'opacity-100',
                     showAlbumLabels &&
                       'border-brand-red text-brand-red hover:text-brand-red-dark'
                   )}


### PR DESCRIPTION
## Problem

Flipping between **Convert to JPG** and **Revert to Grid** caused visible layout jank in the results-header action row, from two sources:

1. **An extra button is inserted.** The *Labels On/Off* button was only mounted in JPG view (`{isJpgView && ...}`). Entering JPG view added a whole button to the flex row, shifting the *Share Grid* button.
2. **The toggle button changes size.** *Convert to JPG* rendered an icon + text, while *Revert to Grid* rendered text only — so the button resized on every toggle and reflowed its neighbors.

## Changes (`app/page.tsx`)

- **Reserve the Labels button's slot.** It is now always mounted and simply hidden with `invisible pointer-events-none` (visibility, which keeps layout footprint) when not in JPG view. It also gets `disabled`, `aria-hidden`, and `tabIndex={-1}` while hidden so it stays out of the tab order and is inert. Entering JPG view now reveals it in place instead of pushing neighbors.
- **Lock the toggle button's size.** It now uses a consistent leading icon in both states (`LayoutGrid` for *Revert to Grid*, `FileImage` for *Convert to JPG*) plus `min-w-[8.5rem]` and `justify-center`, so it stays a fixed size across toggles.

## Notes

These are presentation-only changes — no behavior, data flow, or button actions changed. Project dependencies weren't installed in this environment, so lint/build weren't run here; the edits are confined to JSX/className changes. No tests reference the affected button labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019pLC9xq4DDD8P1WCnwDHgY)_