### PR TITLE
Persist shared grids forever

### DIFF
--- a/app/api/albums/route.test.ts
+++ b/app/api/albums/route.test.ts
@@ -39,7 +39,6 @@ jest.mock('../../../lib/firebase', () => ({
     asNumber: () => {
       if (key === 'lastfm_cache_expiry_seconds') return 3600;
       if (key === 'not_found_cache_expiry_seconds') return 600;
-      if (key === 'shared_grid_expiry_days') return 30;
       return 0;
     },
     asString: () => '',
@@ -163,9 +162,7 @@ describe('GET /api/albums', () => {
     );
     expect(redis.set).toHaveBeenCalledWith(
       `share:${mockSharedId}`,
-      expect.stringContaining(`"id":"${mockSharedId}"`),
-      'EX',
-      2592000
+      expect.stringContaining(`"id":"${mockSharedId}"`)
     );
     expect(response.status).toBe(200);
     expect(responseBody.albums).toEqual(expectedAlbums);

--- a/app/api/albums/route.ts
+++ b/app/api/albums/route.ts
@@ -183,6 +183,10 @@ export async function GET(req: NextRequest) {
 
     try {
       // Shared grids are stored without an expiry so share links never break.
+      // NOTE: this relies on the Redis instance being durable for these keys —
+      // configure it for persistence with a volatile-* eviction policy (or no
+      // eviction), so permanent share data isn't silently evicted under memory
+      // pressure.
       await redis.set(`share:${sharedId}`, JSON.stringify(sharedGridData));
       logger.info(
         CTX,

--- a/app/api/albums/route.ts
+++ b/app/api/albums/route.ts
@@ -182,21 +182,8 @@ export async function GET(req: NextRequest) {
     };
 
     try {
-      // Get shared_grid_expiry_days from Remote Config
-      const remoteConfigExpiryDays = getRemoteConfigValue(
-        'shared_grid_expiry_days'
-      ).asNumber();
-      const defaultExpiryDays = 30;
-      const expiryDays =
-        remoteConfigExpiryDays > 0 ? remoteConfigExpiryDays : defaultExpiryDays;
-      const expirySeconds = expiryDays * 24 * 60 * 60;
-
-      await redis.set(
-        `share:${sharedId}`,
-        JSON.stringify(sharedGridData),
-        'EX',
-        expirySeconds
-      );
+      // Shared grids are stored without an expiry so share links never break.
+      await redis.set(`share:${sharedId}`, JSON.stringify(sharedGridData));
       logger.info(
         CTX,
         `Successfully saved shared grid data to Redis for id: ${sharedId}`

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -47,7 +47,6 @@ if (remoteConfig) {
 // Set default values (optional, but recommended)
 export const defaultRemoteConfig = {
   show_footer_feature_text: false, // Default value for our example feature
-  shared_grid_expiry_days: 30, // Default expiry in days
   default_time_period: '1month', // Default time period
   lastfm_cache_expiry_seconds: 3600, // Default cache expiry in seconds
   not_found_cache_expiry_seconds: 86400, // Default not found cache expiry in seconds


### PR DESCRIPTION
## Summary

Shared grids previously expired. The `share:<id>` Redis key was written with a TTL derived from the `shared_grid_expiry_days` Remote Config flag (default **30 days**), so share links silently broke ~30 days after creation.

This change stores the share key **without an expiry**, so shared grids stay around forever.

## Changes

- `app/api/albums/route.ts` — write `share:<id>` with a plain `redis.set` (no `EX`/TTL). Removed the expiry-day computation and Remote Config lookup.
- `lib/firebase.ts` — removed the now-unused `shared_grid_expiry_days` default from `defaultRemoteConfig`.
- `app/api/albums/route.test.ts` — updated assertion to expect no TTL args; removed the stale config mock.

## Note on existing grids

Grids already stored in Redis still carry their original ~30-day TTL and will expire normally. This change guarantees *newly created* grids persist forever. Retroactively persisting existing keys would require a one-off `SCAN share:* + PERSIST` — out of scope here.

## Verification

- `npm test -- --testPathPattern=albums` ✅ 11 passed
- `npm run lint` ✅ no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pce9ShDyrhvmpzzKZTc2Po)_