### PR TITLE
Remove redundant album name hover overlay on grid covers

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1000,14 +1000,6 @@ export default function Home() {
                               />
                             </a>
                           )}
-                          <div className="absolute bottom-0 inset-x-0 bg-black/70 px-2 py-1.5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-20">
-                            <p className="text-white text-xs font-semibold truncate">
-                              {album.name}
-                            </p>
-                            <p className="text-white/80 text-xs truncate">
-                              {album.artist.name}
-                            </p>
-                          </div>
                         </div>
                         <div className="pt-1.5 pb-1 min-w-0">
                           <p className="text-[11px] font-semibold truncate leading-tight">


### PR DESCRIPTION
## Summary
- Removes the dark hover/tap overlay on album grid covers that showed the album name and artist over the cover image.
- This was redundant since the album/artist name is already displayed below each cover.
- The Spotify "play" hover overlay (dimming + play icon, shown only when a Spotify link is available) is untouched.

## Test plan
- [x] `npm test -- --testPathPatterns=page.test` (full suite: 12 suites, 50 tests passed)
- [x] `npm run lint` (no warnings or errors)


---
_Generated by [Claude Code](https://claude.ai/code/session_017gCA9iNr6MwMZn2WMtErmj)_