### PR TITLE
Add Google Analytics custom event tracking

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -539,6 +539,17 @@ describe('Home Page - Analytics tracking', () => {
       expect(mockedTrackEvent).toHaveBeenCalledWith('view_toggle', {
         direction: 'to_jpg',
       });
+
+      const revertButton = await screen.findByRole('button', {
+        name: /Revert to Grid/,
+      });
+      await waitFor(() => expect(revertButton).not.toBeDisabled());
+      fireEvent.click(revertButton);
+      await screen.findByTestId('album-grid-container');
+
+      expect(mockedTrackEvent).toHaveBeenCalledWith('view_toggle', {
+        direction: 'to_grid',
+      });
     } finally {
       if (srcDescriptor) {
         Object.defineProperty(HTMLImageElement.prototype, 'src', srcDescriptor);

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -5,7 +5,7 @@ import {
   screen,
   fireEvent,
   act,
-  // waitFor, // Removed unused import
+  waitFor,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Home from './page';
@@ -410,6 +410,52 @@ describe('Home Page - Analytics tracking', () => {
     expect(mockedTrackEvent).not.toHaveBeenCalledWith(
       'generate_grid',
       expect.anything()
+    );
+  });
+
+  it('tracks share_grid with username and shared_id when Share button is clicked', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(async (url: RequestInfo | URL) => {
+      const urlString = url.toString();
+      if (urlString.startsWith('/api/albums')) {
+        return {
+          ok: true,
+          json: async () => ({
+            albums: mockApiAlbumsPayload,
+            sharedId: 'test-share-id',
+          }),
+        };
+      }
+      if (urlString.startsWith('/api/spotify-link')) {
+        return { ok: true, json: async () => ({ spotifyUrl: null }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<Home />);
+
+    fireEvent.change(screen.getByPlaceholderText('LastFM Username'), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Grid' }));
+
+    await screen.findByTestId('album-grid-container');
+
+    fireEvent.click(screen.getByRole('button', { name: /Share Grid/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+    expect(mockedTrackEvent).toHaveBeenCalledWith(
+      'share_grid',
+      expect.objectContaining({
+        username: 'testuser',
+        shared_id: 'test-share-id',
+      })
     );
   });
 });

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -558,6 +558,52 @@ describe('Home Page - Analytics tracking', () => {
       HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
     }
   });
+
+  it('tracks spotify_link_click with username when the Spotify overlay link is clicked', async () => {
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(async (url: RequestInfo | URL) => {
+      const urlString = url.toString();
+      if (urlString.startsWith('/api/albums')) {
+        return {
+          ok: true,
+          json: async () => ({
+            albums: mockApiAlbumsPayload,
+            sharedId: 'test-share-id',
+          }),
+        };
+      }
+      if (urlString.startsWith('/api/spotify-link')) {
+        return {
+          ok: true,
+          json: async () => ({
+            spotifyUrl: 'https://open.spotify.com/album/mockedalbum',
+          }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<Home />);
+
+    fireEvent.change(screen.getByPlaceholderText('LastFM Username'), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Grid' }));
+
+    await screen.findByTestId('album-grid-container');
+
+    const spotifyLinks = await screen.findAllByRole('link', {
+      name: 'Play on Spotify',
+    });
+
+    mockedTrackEvent.mockClear();
+    fireEvent.click(spotifyLinks[0]);
+
+    expect(mockedTrackEvent).toHaveBeenCalledWith(
+      'spotify_link_click',
+      expect.objectContaining({ username: 'testuser' })
+    );
+  });
 });
 
 describe('Home Page - JPG label toggle cache invalidation', () => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -9,6 +9,11 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Home from './page';
+import { trackEvent } from '@/lib/analytics';
+
+jest.mock('@/lib/analytics', () => ({
+  trackEvent: jest.fn(),
+}));
 
 jest.mock('@/lib/firebase', () => ({
   getRemoteConfigValue: jest.fn((key: string) => ({
@@ -319,6 +324,93 @@ describe('Home Page - Basic Rendering', () => {
     expect(
       screen.getByRole('button', { name: 'Generate Grid' })
     ).toBeInTheDocument();
+  });
+});
+
+describe('Home Page - Analytics tracking', () => {
+  const mockedTrackEvent = trackEvent as jest.Mock;
+
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    mockedTrackEvent.mockClear();
+  });
+
+  it('tracks generate_grid with username, time_range, and grid_size on success', async () => {
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(async (url: RequestInfo | URL) => {
+      const urlString = url.toString();
+      if (urlString.startsWith('/api/albums')) {
+        return {
+          ok: true,
+          json: async () => ({
+            albums: mockApiAlbumsPayload,
+            sharedId: 'test-share-id',
+          }),
+        };
+      }
+      if (urlString.startsWith('/api/spotify-link')) {
+        return { ok: true, json: async () => ({ spotifyUrl: null }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<Home />);
+
+    fireEvent.change(screen.getByPlaceholderText('LastFM Username'), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Grid' }));
+
+    await screen.findByTestId('album-grid-container');
+
+    expect(mockedTrackEvent).toHaveBeenCalledWith(
+      'generate_grid',
+      expect.objectContaining({
+        username: 'testuser',
+        time_range: '1month',
+        grid_size: 9,
+      })
+    );
+    expect(mockedTrackEvent).not.toHaveBeenCalledWith(
+      'generate_grid_failed',
+      expect.anything()
+    );
+  });
+
+  it('tracks generate_grid_failed with time_range and error_reason on failure', async () => {
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(async (url: RequestInfo | URL) => {
+      const urlString = url.toString();
+      if (urlString.startsWith('/api/albums')) {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ message: 'Last.fm user not found' }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<Home />);
+
+    fireEvent.change(screen.getByPlaceholderText('LastFM Username'), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Grid' }));
+
+    await screen.findByText('Last.fm user not found');
+
+    expect(mockedTrackEvent).toHaveBeenCalledWith(
+      'generate_grid_failed',
+      expect.objectContaining({
+        time_range: '1month',
+        error_reason: 'Last.fm user not found',
+      })
+    );
+    expect(mockedTrackEvent).not.toHaveBeenCalledWith(
+      'generate_grid',
+      expect.anything()
+    );
   });
 });
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -458,6 +458,95 @@ describe('Home Page - Analytics tracking', () => {
       })
     );
   });
+
+  it('tracks view_toggle with direction "to_jpg" when the Grid⇄JPG toggle is clicked', async () => {
+    // The default canvas mocks at the top of this file return a null 2D
+    // context, which is fine for tests that never render a JPG. Converting
+    // to JPG here requires generateImage() to actually succeed, so we swap in
+    // a fake context covering everything generateImage/logo colour analysis
+    // touch — same pattern as the "JPG label toggle cache invalidation" suite.
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+    const srcDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLImageElement.prototype,
+      'src'
+    );
+
+    const fakeCtx = {
+      fillStyle: '',
+      font: '',
+      textAlign: '',
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: '',
+      fillRect: jest.fn(),
+      drawImage: jest.fn(),
+      fillText: jest.fn(),
+      measureText: jest.fn(() => ({ width: 10 })),
+      getImageData: jest.fn(() => ({
+        data: new Uint8ClampedArray(64 * 64 * 4),
+      })),
+    };
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => fakeCtx
+    ) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.toDataURL = jest.fn(
+      () => 'data:image/jpeg;base64,gen-1'
+    );
+    Object.defineProperty(HTMLImageElement.prototype, 'src', {
+      configurable: true,
+      get() {
+        return this._src ?? '';
+      },
+      set(value: string) {
+        this._src = value;
+        if (typeof this.onload === 'function') {
+          Promise.resolve().then(() => this.onload(new Event('load')));
+        }
+      },
+    });
+
+    try {
+      mockFetch.mockReset();
+      mockFetch.mockImplementation(async (url: RequestInfo | URL) => {
+        const urlString = url.toString();
+        if (urlString.startsWith('/api/albums')) {
+          return {
+            ok: true,
+            json: async () => ({
+              albums: mockApiAlbumsPayload,
+              sharedId: 'test-share-id',
+            }),
+          };
+        }
+        if (urlString.startsWith('/api/spotify-link')) {
+          return { ok: true, json: async () => ({ spotifyUrl: null }) };
+        }
+        return { ok: false, status: 404, json: async () => ({}) };
+      });
+
+      render(<Home />);
+
+      fireEvent.change(screen.getByPlaceholderText('LastFM Username'), {
+        target: { value: 'testuser' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Generate Grid' }));
+
+      await screen.findByTestId('album-grid-container');
+
+      fireEvent.click(screen.getByRole('button', { name: /Convert to JPG/ }));
+      await screen.findByAltText('Album Grid JPG');
+
+      expect(mockedTrackEvent).toHaveBeenCalledWith('view_toggle', {
+        direction: 'to_jpg',
+      });
+    } finally {
+      if (srcDescriptor) {
+        Object.defineProperty(HTMLImageElement.prototype, 'src', srcDescriptor);
+      }
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+      HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+    }
+  });
 });
 
 describe('Home Page - JPG label toggle cache invalidation', () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -646,6 +646,7 @@ export default function Home() {
       .writeText(url)
       .then(() => {
         setShareCopied(true);
+        trackEvent('share_grid', { username, shared_id: sharedId });
         setTimeout(() => {
           setShareCopied(false);
         }, 2000); // Reset after 2 seconds

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -663,6 +663,8 @@ export default function Home() {
   const handleToggleView = () => {
     if (viewPhase !== 'idle' || isPreparingJpg) return;
 
+    trackEvent('view_toggle', { direction: isJpgView ? 'to_grid' : 'to_jpg' });
+
     const reduceMotion = window.matchMedia(
       '(prefers-reduced-motion: reduce)'
     ).matches;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1002,6 +1002,9 @@ export default function Home() {
                               href={currentSpotifyUrl}
                               target="_blank"
                               rel="noopener noreferrer"
+                              onClick={() =>
+                                trackEvent('spotify_link_click', { username })
+                              }
                               className={`absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 spotify-icon-overlay ${logoBgType === 'light' ? 'spotify-logo-light-bg' : 'spotify-logo-dark-bg'}`}
                             >
                               <Image

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ import {
 import { FileImage, LayoutGrid, Share2, Check, Loader2 } from 'lucide-react'; // Added Share2, Check, Loader2, LayoutGrid
 import { ThemeToggleButton } from '@/components/theme-toggle-button';
 import type { MinimizedAlbum } from '@/lib/minimizedLastfmService'; // Import MinimizedAlbum
+import { trackEvent } from '@/lib/analytics';
 import {
   getRemoteConfigValue, // This will be used for FTUE and default_time_period
   defaultRemoteConfig,
@@ -277,6 +278,11 @@ export default function Home() {
 
         if (typeof responseData.sharedId === 'string') {
           setSharedId(responseData.sharedId);
+          trackEvent('generate_grid', {
+            username,
+            time_range: timeRange,
+            grid_size: gridSize,
+          });
         } else if (responseData.sharedId === null && responseData.error) {
           setSharedId(null);
           //setError('Fetched albums, but could not generate a shareable link. The grid is not shareable at the moment.');
@@ -306,6 +312,10 @@ export default function Home() {
         setError('An unknown error occurred. Please check the console.');
         console.error('Unknown error details:', err);
       }
+      trackEvent('generate_grid_failed', {
+        time_range: timeRange,
+        error_reason: err instanceof Error ? err.message : 'unknown_error',
+      });
       setSharedId(null); // Ensure sharedId is reset on error
       setAlbums([]); // Clear albums on error
     } finally {

--- a/docs/superpowers/plans/2026-07-09-ga-event-tracking.md
+++ b/docs/superpowers/plans/2026-07-09-ga-event-tracking.md
@@ -1,0 +1,314 @@
+# GA Custom Event Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GA4 custom events (`generate_grid`, `generate_grid_failed`, `share_grid`, `view_toggle`, `spotify_link_click`) to `app/page.tsx` so the existing pageview-only GA setup also captures the engagement funnel.
+
+**Architecture:** A single new helper file `lib/analytics.ts` exports `trackEvent(name, params)`, a thin wrapper around `window.gtag('event', ...)` that no-ops when `gtag` isn't present (SSR, tests, ad-blockers). `app/page.tsx` imports `trackEvent` and calls it at five specific points inside existing handlers — no new UI, no new state.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Jest + ts-jest + `@testing-library/react`, existing inline `gtag.js` script in `app/layout.tsx`.
+
+## Global Constraints
+
+- Keep the existing `gtag.js` script-tag approach — do not migrate to `@next/third-parties` (per spec).
+- Do not track the "Labels On/Off" toggle or the share-page copy-link button (per spec — explicitly out of scope).
+- `username` is intentionally sent as an event parameter on `generate_grid`, `share_grid`, and `spotify_link_click` — this is an approved, deliberate product decision (see spec's Privacy Note), not an oversight to "fix" during implementation.
+- Follow existing code patterns in `app/page.tsx` (function-based handlers, no new abstractions beyond the one helper file).
+
+---
+
+### Task 1: `trackEvent` helper with SSR/no-gtag safety
+
+**Files:**
+- Create: `lib/analytics.ts`
+- Test: `lib/analytics.test.ts`
+
+**Interfaces:**
+- Produces: `trackEvent(name: string, params?: Record<string, string | number | boolean>): void` — imported by `app/page.tsx` in Task 2 onward.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/analytics.test.ts`:
+
+```ts
+import { trackEvent } from './analytics';
+
+describe('trackEvent', () => {
+  const originalGtag = window.gtag;
+
+  afterEach(() => {
+    window.gtag = originalGtag;
+  });
+
+  it('does nothing when window.gtag is undefined', () => {
+    // @ts-expect-error deliberately clearing gtag for this test
+    delete window.gtag;
+    expect(() => trackEvent('generate_grid', { username: 'rj' })).not.toThrow();
+  });
+
+  it('calls window.gtag with the event name and params when gtag exists', () => {
+    const gtagMock = jest.fn();
+    window.gtag = gtagMock;
+
+    trackEvent('generate_grid', { username: 'rj', time_range: 'overall', grid_size: 9 });
+
+    expect(gtagMock).toHaveBeenCalledWith('event', 'generate_grid', {
+      username: 'rj',
+      time_range: 'overall',
+      grid_size: 9,
+    });
+  });
+
+  it('calls window.gtag with no params object when none is passed', () => {
+    const gtagMock = jest.fn();
+    window.gtag = gtagMock;
+
+    trackEvent('view_toggle_test_noop');
+
+    expect(gtagMock).toHaveBeenCalledWith('event', 'view_toggle_test_noop', undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --testPathPattern=lib/analytics.test.ts`
+Expected: FAIL — `Cannot find module './analytics'` (file doesn't exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/analytics.ts`:
+
+```ts
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function trackEvent(
+  name: string,
+  params?: Record<string, string | number | boolean>
+): void {
+  if (typeof window === 'undefined' || !window.gtag) return;
+  window.gtag('event', name, params);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPattern=lib/analytics.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/analytics.ts lib/analytics.test.ts
+git commit -m "feat: add trackEvent GA helper"
+```
+
+---
+
+### Task 2: `generate_grid` and `generate_grid_failed` events in `fetchTopAlbums`
+
+**Files:**
+- Modify: `app/page.tsx:219-315` (the `fetchTopAlbums` function)
+
+**Interfaces:**
+- Consumes: `trackEvent(name: string, params?: Record<string, string | number | boolean>): void` from `lib/analytics.ts` (Task 1).
+
+**Context:** `fetchTopAlbums` (app/page.tsx:219) reads `username` (string) and `timeRange` (string) and `gridSize` (`9 | 16 | 25`) from component state (already in scope in this function — see `app/page.tsx:246`). On success, `responseData.sharedId` is set via `setSharedId(responseData.sharedId)` at line 279. On failure, the `catch` block at line 301 sets `error` from `err.message` when `err instanceof Error`.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `app/page.tsx`, alongside the other local imports, add:
+
+```ts
+import { trackEvent } from '@/lib/analytics';
+```
+
+(Match whatever import alias style — `@/lib/...` vs relative — the file already uses for other `lib/` imports; check an existing `from '@/lib/...'` or `from '../lib/...'` line and mirror it exactly.)
+
+- [ ] **Step 2: Fire `generate_grid` on success**
+
+In `fetchTopAlbums`, immediately after the `if (typeof responseData.sharedId === 'string') { setSharedId(responseData.sharedId); }` branch (app/page.tsx:278-279), add the event call inside that same `if` block:
+
+```ts
+        if (typeof responseData.sharedId === 'string') {
+          setSharedId(responseData.sharedId);
+          trackEvent('generate_grid', {
+            username,
+            time_range: timeRange,
+            grid_size: gridSize,
+          });
+        } else if (responseData.sharedId === null && responseData.error) {
+```
+
+- [ ] **Step 3: Fire `generate_grid_failed` on error**
+
+In the `catch (err: Error | unknown)` block (app/page.tsx:301-310), add the event call right after the existing `if (err instanceof Error) { ... } else { ... }` branch, before `setSharedId(null)`:
+
+```ts
+    } catch (err: Error | unknown) {
+      console.error('An error occurred: ', err);
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('An unknown error occurred. Please check the console.');
+        console.error('Unknown error details:', err);
+      }
+      trackEvent('generate_grid_failed', {
+        time_range: timeRange,
+        error_reason: err instanceof Error ? err.message : 'unknown_error',
+      });
+      setSharedId(null); // Ensure sharedId is reset on error
+      setAlbums([]); // Clear albums on error
+```
+
+- [ ] **Step 4: Manual verification (no automated test — see Task 6 for why)**
+
+Run: `npm run dev`
+In the browser, open DevTools → Network tab, filter on `google-analytics` or `collect`. Enter a valid Last.fm username and generate a grid — confirm a `generate_grid` beacon fires. Enter an invalid/nonexistent username and generate a grid — confirm a `generate_grid_failed` beacon fires.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: track generate_grid and generate_grid_failed GA events"
+```
+
+---
+
+### Task 3: `share_grid` event in `handleShareGrid`
+
+**Files:**
+- Modify: `app/page.tsx:629-647` (the `handleShareGrid` function)
+
+**Interfaces:**
+- Consumes: `trackEvent` from `lib/analytics.ts` (Task 1, already imported in Task 2).
+
+**Context:** `handleShareGrid` (app/page.tsx:629) reads `sharedId` and `username` from component state, and copies a share URL to the clipboard via `navigator.clipboard.writeText(url).then(...)`.
+
+- [ ] **Step 1: Fire `share_grid` after a successful copy**
+
+Modify the `.then()` callback at app/page.tsx:637-642:
+
+```ts
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        setShareCopied(true);
+        trackEvent('share_grid', { username, shared_id: sharedId });
+        setTimeout(() => {
+          setShareCopied(false);
+        }, 2000); // Reset after 2 seconds
+      })
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run: `npm run dev`. Generate a grid, click the "Share" button, confirm (via DevTools Network tab, filter `collect`) a `share_grid` beacon fires with `shared_id` matching the current share URL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: track share_grid GA event"
+```
+
+---
+
+### Task 4: `view_toggle` event in `handleToggleView`
+
+**Files:**
+- Modify: `app/page.tsx:652-698` (the `handleToggleView` function)
+
+**Interfaces:**
+- Consumes: `trackEvent` from `lib/analytics.ts` (Task 1).
+
+**Context:** `handleToggleView` (app/page.tsx:652) branches on the current `isJpgView` boolean: if true, it animates back to grid view (`setIsJpgView(false)`); if false, it generates the JPG and animates into JPG view (`setIsJpgView(true)`). The direction is known at the top of the function, before any state changes.
+
+- [ ] **Step 1: Fire `view_toggle` at the start of the function, direction based on current `isJpgView`**
+
+Modify app/page.tsx:652-653:
+
+```ts
+  const handleToggleView = () => {
+    if (viewPhase !== 'idle' || isPreparingJpg) return;
+
+    trackEvent('view_toggle', { direction: isJpgView ? 'to_grid' : 'to_jpg' });
+
+    const reduceMotion = window.matchMedia(
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run: `npm run dev`. Generate a grid, click the Grid⇄JPG toggle button in both directions, confirm two `view_toggle` beacons fire with `direction: "to_jpg"` then `direction: "to_grid"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: track view_toggle GA event"
+```
+
+---
+
+### Task 5: `spotify_link_click` event on the Spotify overlay link
+
+**Files:**
+- Modify: `app/page.tsx:987-999` (the Spotify `<a>` overlay)
+
+**Interfaces:**
+- Consumes: `trackEvent` from `lib/analytics.ts` (Task 1).
+
+**Context:** The Spotify link (app/page.tsx:988-993) is a plain anchor with `href={currentSpotifyUrl}`, `target="_blank"`, no `onClick` yet. `username` is already in scope in this render (component state).
+
+- [ ] **Step 1: Add an `onClick` handler to the anchor**
+
+```tsx
+                          {currentSpotifyUrl && (
+                            <a
+                              href={currentSpotifyUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={() => trackEvent('spotify_link_click', { username })}
+                              className={`absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 spotify-icon-overlay ${logoBgType === 'light' ? 'spotify-logo-light-bg' : 'spotify-logo-dark-bg'}`}
+                            >
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run: `npm run dev`. Generate a grid, hover an album cover to reveal the Spotify overlay, click it, confirm a `spotify_link_click` beacon fires (the link opening in a new tab doesn't interrupt the beacon since it's a normal anchor navigation, not a full page unload of the current tab).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: track spotify_link_click GA event"
+```
+
+---
+
+### Task 6: Full test suite regression check
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: All existing tests still PASS. `app/page.tsx` has no direct unit tests exercising `fetchTopAlbums`/`handleShareGrid`/`handleToggleView` end-to-end with a real `gtag`, so no existing test should need mocking — `trackEvent`'s no-op guard (Task 1) means calls are safe under jsdom, which doesn't define `window.gtag` by default. If any test unexpectedly fails referencing `gtag` or `trackEvent`, investigate before proceeding — do not silence by mocking blindly.
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: No new errors introduced by the changes in Tasks 2-5.
+
+- [ ] **Step 3: Commit (only if Steps 1-2 required fixes)**
+
+```bash
+git add -A
+git commit -m "fix: address lint/test regressions from GA event tracking"
+```
+
+(Skip this commit entirely if Steps 1-2 passed clean with no changes needed.)

--- a/docs/superpowers/specs/2026-07-09-ga-event-tracking-design.md
+++ b/docs/superpowers/specs/2026-07-09-ga-event-tracking-design.md
@@ -1,0 +1,63 @@
+# Google Analytics Event Tracking — Design
+
+## Context
+
+GA4 pageview tracking is already wired up in `app/layout.tsx` via inline `gtag.js` script tags, driven by `NEXT_PUBLIC_GA_MEASUREMENT_ID`. This only reports pageviews, giving no insight into how users actually use the grid generator (which features get used, where users drop off, whether shares/downloads happen). This design adds custom GA4 events for the key interactions in the app to build an engagement funnel.
+
+## Goals
+
+- Track: grid generation (success/failure), grid sharing, grid↔JPG view toggling, Spotify link clicks.
+- Keep implementation minimal and consistent with the existing `gtag.js` script-tag setup (no migration to `@next/third-parties`).
+- Centralize event-firing through one small helper rather than scattering raw `window.gtag` calls.
+
+## Non-goals
+
+- Migrating the GA loading mechanism.
+- Tracking the "Labels On/Off" toggle or the share-page's own copy-link button — these are minor UI state, not funnel-relevant, and are explicitly excluded to avoid event noise.
+- Consent management / cookie banner — out of scope for this change (see Privacy Note below).
+
+## Privacy Note
+
+The `username` field entered by the user (a Last.fm username, not necessarily a real name but potentially identifying) will be sent as an event parameter on `generate_grid`, `share_grid`, and `spotify_link_click`. This is an explicit product decision (confirmed with stakeholder) to enable repeat-user analysis. Sending user-identifying data to Google Analytics typically requires disclosure in a privacy policy; if this site doesn't have one, that should be added separately (tracked as a follow-up, not part of this change).
+
+## Design
+
+### 1. Central events helper — `lib/analytics.ts` (new file)
+
+```ts
+export function trackEvent(name: string, params?: Record<string, string | number | boolean>) {
+  if (typeof window === 'undefined' || !window.gtag) return;
+  window.gtag('event', name, params);
+}
+```
+
+Add an ambient type declaration (likely in this same file, or `lib/types.ts`) so `window.gtag` type-checks without `any`/`@ts-ignore`:
+
+```ts
+declare global {
+  interface Window {
+    gtag: (...args: unknown[]) => void;
+  }
+}
+```
+
+### 2. Call sites — all in `app/page.tsx`
+
+| Event | Trigger location | Params |
+|---|---|---|
+| `generate_grid` | Success path inside `fetchTopAlbums`, after `setSharedId(responseData.sharedId)` (~line 279) | `username`, `time_range`, `grid_size` |
+| `generate_grid_failed` | Catch/error path inside `fetchTopAlbums` | `time_range`, `error_reason` (e.g. `"user_not_found"`, `"api_error"`) |
+| `share_grid` | Inside `handleShareGrid` (line 629) | `username`, `shared_id` |
+| `view_toggle` | Inside `handleToggleView` (line 652) | `direction` (`"to_jpg"` \| `"to_grid"`) |
+| `spotify_link_click` | New `onClick` handler added to the existing `<a href={currentSpotifyUrl}>` at line 988 | `username` |
+
+`error_reason` values should map to the existing error branches already present in `fetchTopAlbums`'s catch/error handling — use whatever distinct failure cases that function already distinguishes (e.g. user-not-found vs. generic API failure); don't invent new error categories not already handled.
+
+### 3. Testing
+
+- Unit test `lib/analytics.ts`: `trackEvent` is a no-op when `window.gtag` is undefined (SSR/test environment), and calls `window.gtag('event', name, params)` when it's defined.
+- No new tests needed for `app/page.tsx` call sites beyond ensuring existing tests still pass (mocking `window.gtag` as needed if it's undefined in jsdom and causes noise).
+
+## Open questions
+
+None — design approved by stakeholder.

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -17,7 +17,11 @@ describe('trackEvent', () => {
     const gtagMock = jest.fn();
     window.gtag = gtagMock;
 
-    trackEvent('generate_grid', { username: 'rj', time_range: 'overall', grid_size: 9 });
+    trackEvent('generate_grid', {
+      username: 'rj',
+      time_range: 'overall',
+      grid_size: 9,
+    });
 
     expect(gtagMock).toHaveBeenCalledWith('event', 'generate_grid', {
       username: 'rj',
@@ -32,6 +36,10 @@ describe('trackEvent', () => {
 
     trackEvent('view_toggle_test_noop');
 
-    expect(gtagMock).toHaveBeenCalledWith('event', 'view_toggle_test_noop', undefined);
+    expect(gtagMock).toHaveBeenCalledWith(
+      'event',
+      'view_toggle_test_noop',
+      undefined
+    );
   });
 });

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,0 +1,37 @@
+import { trackEvent } from './analytics';
+
+describe('trackEvent', () => {
+  const originalGtag = window.gtag;
+
+  afterEach(() => {
+    window.gtag = originalGtag;
+  });
+
+  it('does nothing when window.gtag is undefined', () => {
+    // @ts-expect-error deliberately clearing gtag for this test
+    delete window.gtag;
+    expect(() => trackEvent('generate_grid', { username: 'rj' })).not.toThrow();
+  });
+
+  it('calls window.gtag with the event name and params when gtag exists', () => {
+    const gtagMock = jest.fn();
+    window.gtag = gtagMock;
+
+    trackEvent('generate_grid', { username: 'rj', time_range: 'overall', grid_size: 9 });
+
+    expect(gtagMock).toHaveBeenCalledWith('event', 'generate_grid', {
+      username: 'rj',
+      time_range: 'overall',
+      grid_size: 9,
+    });
+  });
+
+  it('calls window.gtag with no params object when none is passed', () => {
+    const gtagMock = jest.fn();
+    window.gtag = gtagMock;
+
+    trackEvent('view_toggle_test_noop');
+
+    expect(gtagMock).toHaveBeenCalledWith('event', 'view_toggle_test_noop', undefined);
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function trackEvent(
+  name: string,
+  params?: Record<string, string | number | boolean>
+): void {
+  if (typeof window === 'undefined' || !window.gtag) return;
+  window.gtag('event', name, params);
+}


### PR DESCRIPTION
## Summary
- Adds GA4 custom events to build an engagement funnel beyond basic pageviews: `generate_grid`/`generate_grid_failed`, `share_grid`, `view_toggle` (to_jpg/to_grid), `spotify_link_click`
- Centralizes event firing through a new `lib/analytics.ts` `trackEvent()` helper (SSR/no-gtag safe)
- `username` is intentionally included as an event param on `generate_grid`, `share_grid`, and `spotify_link_click` (approved product decision) — may warrant a privacy policy disclosure as a follow-up

## Test plan
- [x] Full suite passes (58/58 tests, 13 suites)
- [x] Lint clean
- [x] Each event has an automated RTL test asserting `trackEvent` fires with correct name/params (upgraded from manual-verification-only per plan, with TDD break/restore checks)
- [x] Reviewed task-by-task plus a final whole-branch review — no Critical/Important findings

Design spec: `docs/superpowers/specs/2026-07-09-ga-event-tracking-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-09-ga-event-tracking.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)